### PR TITLE
chore: improve suggestion error logging

### DIFF
--- a/src/pages/tabs/Suggestions.tsx
+++ b/src/pages/tabs/Suggestions.tsx
@@ -53,10 +53,11 @@ export default function SuggestionsTab({
             setSuggestions(response.suggestions);
             setFollowUpQuestions(response.followUpQuestions);
         } catch (error) {
-            console.error("Error fetching suggestions:", error);
+            const message = error instanceof Error ? error.message : JSON.stringify(error);
+            console.error("Error fetching suggestions:", message, error);
             toast({
                 title: "Error fetching suggestions",
-                description: error instanceof Error ? error.message : "Please try again.",
+                description: message,
             });
         } finally {
             setIsFetchingSuggestions(false);


### PR DESCRIPTION
## Summary
- improve logging in Suggestions tab error toast

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: see log for details)
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6895d40d2f1883318f603cac8cfdbdf4